### PR TITLE
Support private repo dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       run-build: false
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,4 +13,7 @@ jobs:
   security:
     uses: brooksmcmillin/workflows/.github/workflows/python-security.yml@main
     with:
-      package-name: agent_framework
+      package-name: agents
+      pre-install-command: uv add agent-framework@git+https://github.com/brooksmcmillin/agent-framework
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
- Pass GH_PAT secret to reusable workflows for private repo access
- Fix security workflow package-name (was agent_framework, now agents)
- Add pre-install-command to security workflow for agent-framework

Requires GH_PAT secret with repo scope to be configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)