### PR TITLE
Add REST API server for agents with stateless and stateful endpoints

### DIFF
--- a/agents/api/__init__.py
+++ b/agents/api/__init__.py
@@ -1,0 +1,7 @@
+"""REST API for calling agents over HTTP.
+
+Run the server with:
+    uv run python -m agents.api
+"""
+
+__version__ = "0.1.0"

--- a/agents/api/__main__.py
+++ b/agents/api/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point: ``uv run python -m agents.api``."""
+
+import uvicorn
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from .server import app  # noqa: E402
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/agents/api/models.py
+++ b/agents/api/models.py
@@ -1,0 +1,60 @@
+"""Pydantic models for the Agent REST API."""
+
+from pydantic import BaseModel, Field
+
+
+class MessageRequest(BaseModel):
+    """Request body for sending a message to an agent."""
+
+    message: str = Field(..., min_length=1, description="The user message to send to the agent")
+
+
+class TokenUsage(BaseModel):
+    """Token usage statistics for a request."""
+
+    input_tokens: int
+    output_tokens: int
+
+
+class MessageResponse(BaseModel):
+    """Response from an agent after processing a message."""
+
+    response: str
+    agent: str
+    session_id: str | None = None
+    usage: TokenUsage
+
+
+class SessionCreateRequest(BaseModel):
+    """Request body for creating a new session."""
+
+    agent: str = Field(..., description="Agent name (e.g. 'pr', 'chatbot')")
+
+
+class SessionInfo(BaseModel):
+    """Information about an active session."""
+
+    session_id: str
+    agent: str
+    message_count: int
+    context_stats: dict
+
+
+class AgentInfo(BaseModel):
+    """Public metadata about an available agent."""
+
+    name: str
+    description: str
+
+
+class AgentListResponse(BaseModel):
+    """Response listing available agents."""
+
+    agents: list[AgentInfo]
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+
+    status: str = "ok"
+    agents_available: int

--- a/agents/api/server.py
+++ b/agents/api/server.py
@@ -1,0 +1,274 @@
+"""FastAPI REST server exposing agents as HTTP endpoints.
+
+Provides two usage patterns:
+
+1. **Stateless** - Fire a single prompt at an agent and get a response:
+       POST /agents/{name}/message  {"message": "..."}
+
+2. **Stateful sessions** - Multi-turn conversations with preserved history:
+       POST   /sessions              {"agent": "pr"}
+       POST   /sessions/{id}/message {"message": "..."}
+       GET    /sessions/{id}
+       DELETE /sessions/{id}
+
+Run with:
+    uv run python -m agents.api
+"""
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from agent_framework import Agent
+
+from .models import (
+    AgentInfo,
+    AgentListResponse,
+    HealthResponse,
+    MessageRequest,
+    MessageResponse,
+    SessionCreateRequest,
+    SessionInfo,
+    TokenUsage,
+)
+from .sessions import SessionManager
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Agent registry
+#
+# Maps short name -> (AgentClass, constructor kwargs, human description).
+# Populated lazily by _build_registry() on first access so that imports
+# only happen when the server actually starts.
+# ---------------------------------------------------------------------------
+
+_registry: dict[str, tuple[type[Agent], dict[str, Any] | None, str]] | None = None
+
+
+def _build_registry() -> dict[str, tuple[type[Agent], dict[str, Any] | None, str]]:
+    """Build the agent registry.
+
+    Imports are deferred to here so the module can be imported without
+    triggering heavyweight side-effects (Anthropic client init, etc.).
+    """
+    from agents.business_advisor.main import BusinessAdvisorAgent
+    from agents.chatbot.main import ChatbotAgent
+    from agents.pr_agent.main import PRAgent
+    from agents.security_researcher.main import SecurityResearcherAgent
+    from agents.task_manager.main import TaskManagerAgent
+    from shared import DEFAULT_MCP_SERVER_URL, ENV_MCP_SERVER_URL
+
+    return {
+        "chatbot": (
+            ChatbotAgent,
+            None,
+            "General-purpose chatbot with full MCP tool access",
+        ),
+        "pr": (
+            PRAgent,
+            None,
+            "PR and content strategy assistant",
+        ),
+        "tasks": (
+            TaskManagerAgent,
+            {
+                "mcp_urls": [os.getenv(ENV_MCP_SERVER_URL, DEFAULT_MCP_SERVER_URL)],
+                "mcp_client_config": {"prefer_device_flow": True},
+            },
+            "Interactive task management agent",
+        ),
+        "security": (
+            SecurityResearcherAgent,
+            None,
+            "Security research assistant",
+        ),
+        "business": (
+            BusinessAdvisorAgent,
+            {
+                "mcp_urls": ["https://api.githubcopilot.com/mcp/"],
+                "mcp_client_config": {
+                    "auth_token": os.getenv("GITHUB_MCP_PAT"),
+                },
+            },
+            "Business strategy and monetization advisor",
+        ),
+    }
+
+
+def _get_registry() -> dict[str, tuple[type[Agent], dict[str, Any] | None, str]]:
+    global _registry
+    if _registry is None:
+        _registry = _build_registry()
+    return _registry
+
+
+def _create_agent(name: str) -> Agent:
+    """Instantiate a named agent from the registry."""
+    registry = _get_registry()
+    if name not in registry:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{name}' not found. Available: {list(registry.keys())}",
+        )
+    agent_class, kwargs, _ = registry[name]
+    return agent_class(**(kwargs or {}))
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+session_mgr = SessionManager()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Start background tasks on startup, clean up on shutdown."""
+    session_mgr.start_cleanup_loop()
+    logger.info("Agent REST API started")
+    yield
+    logger.info("Agent REST API shutting down")
+
+
+app = FastAPI(
+    title="Agent REST API",
+    description="REST interface for calling agents as stateless endpoints or multi-turn sessions.",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Health & discovery
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    return HealthResponse(agents_available=len(_get_registry()))
+
+
+@app.get("/agents", response_model=AgentListResponse)
+async def list_agents() -> AgentListResponse:
+    registry = _get_registry()
+    return AgentListResponse(
+        agents=[
+            AgentInfo(name=name, description=desc)
+            for name, (_, _, desc) in registry.items()
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stateless one-shot endpoint
+# ---------------------------------------------------------------------------
+
+
+@app.post("/agents/{agent_name}/message", response_model=MessageResponse)
+async def stateless_message(agent_name: str, body: MessageRequest) -> MessageResponse:
+    """Send a single message to an agent with no conversation history.
+
+    A fresh agent is created, processes the message, and is discarded.
+    Use this for simple request/response patterns where you don't need
+    multi-turn context.
+    """
+    agent = _create_agent(agent_name)
+    input_before = agent.total_input_tokens
+    output_before = agent.total_output_tokens
+
+    try:
+        response_text = await agent.process_message(body.message)
+    except Exception as e:
+        logger.exception("Agent %s failed processing message", agent_name)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    return MessageResponse(
+        response=response_text,
+        agent=agent_name,
+        session_id=None,
+        usage=TokenUsage(
+            input_tokens=agent.total_input_tokens - input_before,
+            output_tokens=agent.total_output_tokens - output_before,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session-based (stateful) endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.post("/sessions", response_model=SessionInfo, status_code=201)
+async def create_session(body: SessionCreateRequest) -> SessionInfo:
+    """Create a new session with a persistent agent instance.
+
+    The session keeps conversation history between calls so the agent
+    can reference earlier messages.  Sessions expire after 1 hour of
+    inactivity.
+    """
+    agent = _create_agent(body.agent)
+    session = session_mgr.create(agent)
+    return SessionInfo(
+        session_id=session.id,
+        agent=body.agent,
+        message_count=0,
+        context_stats=agent.get_context_stats(),
+    )
+
+
+@app.post("/sessions/{session_id}/message", response_model=MessageResponse)
+async def session_message(session_id: str, body: MessageRequest) -> MessageResponse:
+    """Send a message within an existing session.
+
+    Conversation history is preserved from prior calls in this session.
+    """
+    session = session_mgr.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+
+    agent = session.agent
+    input_before = agent.total_input_tokens
+    output_before = agent.total_output_tokens
+
+    try:
+        response_text = await agent.process_message(body.message)
+    except Exception as e:
+        logger.exception("Session %s failed processing message", session_id)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    session.touch()
+
+    return MessageResponse(
+        response=response_text,
+        agent=agent.get_agent_name(),
+        session_id=session_id,
+        usage=TokenUsage(
+            input_tokens=agent.total_input_tokens - input_before,
+            output_tokens=agent.total_output_tokens - output_before,
+        ),
+    )
+
+
+@app.get("/sessions/{session_id}", response_model=SessionInfo)
+async def get_session(session_id: str) -> SessionInfo:
+    """Get metadata about an active session."""
+    session = session_mgr.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    return SessionInfo(
+        session_id=session.id,
+        agent=session.agent.get_agent_name(),
+        message_count=len(session.agent.messages),
+        context_stats=session.agent.get_context_stats(),
+    )
+
+
+@app.delete("/sessions/{session_id}", status_code=204)
+async def delete_session(session_id: str) -> None:
+    """End a session and free its resources."""
+    if not session_mgr.delete(session_id):
+        raise HTTPException(status_code=404, detail="Session not found or expired")

--- a/agents/api/sessions.py
+++ b/agents/api/sessions.py
@@ -1,0 +1,90 @@
+"""In-memory session manager for stateful agent conversations.
+
+Sessions hold a reference to an instantiated Agent and are evicted
+after a configurable TTL of inactivity.  This keeps the REST layer
+stateless-friendly (no session = fire-and-forget) while still
+supporting multi-turn conversations when needed.
+
+For horizontal scaling or persistence across restarts, swap this
+store for a Redis-backed implementation with the same interface.
+"""
+
+import asyncio
+import logging
+import time
+import uuid
+
+from agent_framework import Agent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SESSION_TTL = 3600  # 1 hour
+
+
+class Session:
+    """A single agent conversation session."""
+
+    __slots__ = ("id", "agent", "created_at", "last_active")
+
+    def __init__(self, session_id: str, agent: Agent) -> None:
+        self.id = session_id
+        self.agent = agent
+        self.created_at = time.monotonic()
+        self.last_active = self.created_at
+
+    def touch(self) -> None:
+        """Update last-active timestamp."""
+        self.last_active = time.monotonic()
+
+
+class SessionManager:
+    """Manages agent sessions with automatic TTL eviction."""
+
+    def __init__(self, ttl: int = DEFAULT_SESSION_TTL) -> None:
+        self._sessions: dict[str, Session] = {}
+        self._ttl = ttl
+        self._cleanup_task: asyncio.Task | None = None
+
+    def start_cleanup_loop(self) -> None:
+        """Start background task that evicts expired sessions."""
+        if self._cleanup_task is None:
+            self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+
+    async def _cleanup_loop(self) -> None:
+        """Periodically remove sessions that exceed TTL."""
+        while True:
+            await asyncio.sleep(60)
+            now = time.monotonic()
+            expired = [
+                sid
+                for sid, session in self._sessions.items()
+                if now - session.last_active > self._ttl
+            ]
+            for sid in expired:
+                logger.info("Evicting expired session %s", sid)
+                del self._sessions[sid]
+
+    def create(self, agent: Agent) -> Session:
+        """Create a new session wrapping the given agent instance."""
+        session_id = uuid.uuid4().hex[:16]
+        session = Session(session_id, agent)
+        self._sessions[session_id] = session
+        logger.info("Created session %s for %s", session_id, agent.get_agent_name())
+        return session
+
+    def get(self, session_id: str) -> Session | None:
+        """Retrieve a session by ID, or None if not found / expired."""
+        session = self._sessions.get(session_id)
+        if session is None:
+            return None
+        if time.monotonic() - session.last_active > self._ttl:
+            del self._sessions[session_id]
+            return None
+        return session
+
+    def delete(self, session_id: str) -> bool:
+        """Delete a session.  Returns True if it existed."""
+        return self._sessions.pop(session_id, None) is not None
+
+    def active_count(self) -> int:
+        return len(self._sessions)

--- a/bin/run-api
+++ b/bin/run-api
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Start the Agent REST API server.
+
+Usage:
+    uv run python bin/run-api              # Default: 0.0.0.0:8080
+    uv run python bin/run-api --port 3000  # Custom port
+    uv run python bin/run-api --reload     # Auto-reload on code changes
+
+Alternatively:
+    uv run python -m agents.api
+"""
+
+import argparse
+
+import uvicorn
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Start the Agent REST API server.")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind address (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=8080, help="Port (default: 8080)")
+    parser.add_argument(
+        "--reload", action="store_true", help="Enable auto-reload for development"
+    )
+    args = parser.parse_args()
+
+    # Use string import path so uvicorn can handle --reload correctly
+    uvicorn.run(
+        "agents.api.server:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "lxml>=6.0.2",
     "html2text>=2024.2.26",
     "agent-framework",
+    "fastapi>=0.115.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -94,6 +94,7 @@ dependencies = [
     { name = "authlib" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
+    { name = "fastapi" },
     { name = "html2text" },
     { name = "httpx" },
     { name = "lxml" },
@@ -127,6 +128,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.3.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "cryptography", specifier = ">=44.0.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "html2text", specifier = ">=2024.2.26" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "lxml", specifier = ">=6.0.2" },
@@ -255,6 +257,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -724,6 +735,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.128.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
 ]
 
 [[package]]
@@ -1870,15 +1896,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.51.0"
+version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/65/5a1fadcc40c5fdc7df421a7506b79633af8f5d5e3a95c3e72acacec644b9/starlette-0.51.0.tar.gz", hash = "sha256:4c4fda9b1bc67f84037d3d14a5112e523509c369d9d47b111b2f984b0cc5ba6c", size = 2647658, upload-time = "2026-01-10T20:23:15.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/c4/09985a03dba389d4fe16a9014147a7b02fa76ef3519bf5846462a485876d/starlette-0.51.0-py3-none-any.whl", hash = "sha256:fb460a3d6fd3c958d729fdd96aee297f89a51b0181f16401fe8fd4cb6129165d", size = 74133, upload-time = "2026-01-10T20:23:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR introduces a FastAPI-based REST API server that exposes agents as HTTP endpoints, supporting both stateless one-shot requests and stateful multi-turn conversations with session management.

## Key Changes

- **FastAPI Server** (`agents/api/server.py`): Core REST API with:
  - Health check and agent discovery endpoints (`/health`, `/agents`)
  - Stateless endpoint for single-message requests (`POST /agents/{name}/message`)
  - Stateful session endpoints for multi-turn conversations:
    - `POST /sessions` - Create a new session
    - `POST /sessions/{id}/message` - Send message in session
    - `GET /sessions/{id}` - Get session metadata
    - `DELETE /sessions/{id}` - End session
  - Lazy-loaded agent registry to defer imports until server startup
  - Token usage tracking for all requests

- **Session Manager** (`agents/api/sessions.py`): In-memory session store with:
  - Automatic TTL-based eviction (1 hour default inactivity timeout)
  - Background cleanup loop to remove expired sessions
  - Simple interface suitable for swapping with Redis-backed implementation

- **Pydantic Models** (`agents/api/models.py`): Request/response schemas for:
  - Message requests and responses with token usage
  - Session creation and metadata
  - Agent discovery and health checks

- **Entry Points**:
  - `agents/api/__main__.py` - Module entry point (`uv run python -m agents.api`)
  - `bin/run-api` - Standalone script with CLI options for host, port, and auto-reload

- **Dependencies**: Added `fastapi>=0.115.0` to `pyproject.toml`

## Notable Implementation Details

- **Lazy Agent Registry**: Agents are only imported when the server starts, avoiding heavyweight side-effects during module import
- **Flexible Agent Configuration**: Registry supports per-agent constructor kwargs (e.g., MCP URLs, auth tokens)
- **Token Tracking**: Both endpoints track input/output tokens before and after processing
- **Session Lifecycle**: Sessions are automatically cleaned up after TTL expiration, with manual deletion also supported
- **Error Handling**: Proper HTTP status codes and error messages for missing agents/sessions and processing failures

https://claude.ai/code/session_011UFvPWc2EY38ysH6MiV6Se