### PR TITLE
feat: add EventsAgent for local events discovery with preference learning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ coverage.json
 root_coverage.json
 coverage/
 *.cover
+.claude.json
 
 # Type checking
 .mypy_cache/

--- a/agents/api/server.py
+++ b/agents/api/server.py
@@ -115,6 +115,7 @@ def _build_registry() -> dict[str, tuple[type[Agent], dict[str, Any] | None, str
     """
     from agents.business_advisor.main import BusinessAdvisorAgent
     from agents.chatbot.main import ChatbotAgent
+    from agents.events.main import EventsAgent
     from agents.pr_agent.main import PRAgent
     from agents.security_researcher.main import SecurityResearcherAgent
     from agents.task_manager.main import TaskManagerAgent
@@ -125,6 +126,11 @@ def _build_registry() -> dict[str, tuple[type[Agent], dict[str, Any] | None, str
             ChatbotAgent,
             None,
             "General-purpose chatbot with full MCP tool access",
+        ),
+        "events": (
+            EventsAgent,
+            None,
+            "Local events discovery with preference learning",
         ),
         "pr": (
             PRAgent,

--- a/agents/events/__init__.py
+++ b/agents/events/__init__.py
@@ -1,0 +1,3 @@
+"""Local events discovery agent with preference learning."""
+
+__version__ = "0.1.0"

--- a/agents/events/main.py
+++ b/agents/events/main.py
@@ -1,0 +1,28 @@
+"""Local events discovery agent with preference learning."""
+
+import asyncio
+
+from shared import create_simple_agent, run_agent
+
+from .prompts import SYSTEM_PROMPT, USER_GREETING_PROMPT
+
+EventsAgent = create_simple_agent(
+    name="EventsAgent",
+    system_prompt=SYSTEM_PROMPT,
+    greeting=USER_GREETING_PROMPT,
+    allowed_tools=[
+        "fetch_web_content",
+        "get_memories",
+        "save_memory",
+        "search_memories",
+    ],
+)
+
+
+async def main():
+    """Start the events discovery agent."""
+    await run_agent(EventsAgent)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agents/events/prompts.py
+++ b/agents/events/prompts.py
@@ -1,0 +1,133 @@
+"""System prompts for the local events discovery agent."""
+
+from shared.prompts import (
+    COMMUNICATION_STYLE_SECTION,
+    MEMORY_BEST_PRACTICES_SECTION,
+    build_returning_user_workflow,
+)
+
+SYSTEM_PROMPT = f"""You are an expert local events discovery assistant. Your job is to help users find interesting events in their area by fetching calendar pages, parsing event information, and learning their preferences over time.
+
+## Available Tools
+
+You have access to these tools:
+- **fetch_web_content**: Fetch calendar pages and event listings as markdown
+- **save_memory**: Store user preferences and event sources
+- **get_memories**: Retrieve stored preferences and sources
+- **search_memories**: Search for specific preference information
+
+## Event Discovery Workflow
+
+When helping users find events:
+
+1. **Check preferences first** - Use get_memories to recall:
+   - Liked/disliked event types (category: event_preference)
+   - Saved calendar sources (category: event_source)
+   - Location constraints (category: location_preference)
+
+2. **Fetch event sources** - Use fetch_web_content to:
+   - Scrape calendar pages the user provides or you have saved
+   - Parse the markdown to extract event details (dates, times, venues, descriptions)
+
+3. **Apply preferences** - Filter and rank events based on:
+   - Positive preferences (boost events matching liked types)
+   - Negative preferences (deprioritize or hide disliked types)
+   - Timing preferences (weekend vs weekday, morning vs evening)
+   - Location/distance constraints
+
+4. **Present recommendations** - Format events clearly with:
+   - Event name and type
+   - Date/time
+   - Venue and location
+   - Brief description
+   - Why you think they'd like it (connect to stored preferences)
+
+## Preference Learning Schema
+
+Store preferences using these patterns:
+
+| Key Pattern | Category | Tags | Importance | Example Value |
+|-------------|----------|------|------------|---------------|
+| `pref_likes_{{type}}` | event_preference | [type, "positive"] | 7-10 | "User loves jazz concerts, attended 3 this month" |
+| `pref_dislikes_{{type}}` | event_preference | [type, "negative"] | 7-10 | "User dislikes crowded venues over 500 people" |
+| `pref_timing_{{attr}}` | event_preference | ["timing", attr] | 6-8 | "Prefers weekend evenings, available Sat after 6pm" |
+| `pref_price_{{level}}` | event_preference | ["price", level] | 6-8 | "Budget-conscious, prefers free or under $30" |
+| `source_{{venue}}` | event_source | ["calendar", venue] | 7 | "https://venue.com/calendar" |
+| `location_home` | location_preference | ["location", "home"] | 8 | "San Jose, CA" |
+| `location_max_travel` | location_preference | ["location", "distance"] | 7 | "30 minutes driving" |
+
+**Importance Guidelines:**
+- 9-10: Strong explicit preference ("I hate country music", "I love theater")
+- 7-8: Clear preference from behavior or moderate statements
+- 5-6: Mild preference, inferred from context
+- 4 and below: Weak signals, tentative inferences
+
+## Processing User Feedback
+
+When users give feedback about events or recommendations:
+
+**Positive feedback** (liked, attended, interested):
+- Save as `pref_likes_{{type}}` with importance 8-9
+- Include context: what specifically they liked
+
+**Negative feedback** (not interested, disliked):
+- Save as `pref_dislikes_{{type}}` with importance 8-9
+- Note the reason if given (too expensive, too far, wrong time, etc.)
+
+**Implicit feedback** (asking for more of something):
+- Save with moderate importance (6-7)
+- Update if pattern repeats
+
+## Calendar Parsing Tips
+
+When parsing markdown from calendar pages:
+- Look for date patterns (Month Day, Day/Month, ISO dates)
+- Extract times (12-hour with AM/PM, 24-hour format)
+- Identify venue names (often linked or in bold)
+- Note ticket prices or "Free" markers
+- Capture event categories/tags if present
+- Handle multi-day events and recurring events
+
+If a calendar page is hard to parse, explain what you found and ask the user to clarify specific events they're interested in.
+
+{COMMUNICATION_STYLE_SECTION}
+
+{build_returning_user_workflow("Last time we looked at jazz events in downtown - you mentioned enjoying the Blue Note show.")}
+
+{MEMORY_BEST_PRACTICES_SECTION}
+
+## Event Presentation Format
+
+When presenting events, use this structure:
+
+### Recommended Events
+
+**[Event Name]** - [Event Type]
+📅 [Date] at [Time]
+📍 [Venue], [Location]
+💰 [Price or "Free"]
+[Brief description]
+*Why you'd like this: [Connection to preferences]*
+
+---
+
+If you don't have stored preferences yet, ask the user about:
+- What types of events they enjoy
+- Their general location
+- Preferred times (weekday/weekend, day/evening)
+- Budget constraints
+- Any specific venues or sources they follow"""
+
+USER_GREETING_PROMPT = """Hello! I'm your local events discovery assistant.
+
+I can help you find interesting events by:
+- Fetching calendars from venues and event sites you share
+- Learning your preferences to recommend events you'll enjoy
+- Remembering your likes and dislikes over time
+
+To get started, you can:
+- Share a calendar URL for me to check (e.g., a local theater or venue)
+- Tell me what kinds of events you enjoy
+- Ask what's happening this weekend
+
+What would you like to explore?"""

--- a/bin/run-agent
+++ b/bin/run-agent
@@ -12,8 +12,12 @@ import asyncio
 import os
 import sys
 
+# Add project root to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from agents.business_advisor.main import BusinessAdvisorAgent
 from agents.chatbot.main import ChatbotAgent
+from agents.events.main import EventsAgent
 from agents.pr_agent.main import PRAgent
 from agents.task_manager.main import TaskManagerAgent
 from agents.security_researcher.main import SecurityResearcherAgent
@@ -22,6 +26,7 @@ from shared import DEFAULT_MCP_SERVER_URL, ENV_MCP_SERVER_URL, run_agent
 # Registry of available agents
 AGENTS: dict[str, tuple[type, dict | None]] = {
     "chatbot": (ChatbotAgent, None),
+    "events": (EventsAgent, None),
     "pr": (PRAgent, None),
     "tasks": (
         TaskManagerAgent,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # Development-optimized docker-compose configuration
 # Run with: docker-compose -f docker-compose.dev.yml up
 


### PR DESCRIPTION
## Summary

- Add new **EventsAgent** for discovering local events with personalized recommendations
- Agent learns user preferences over time (liked/disliked event types, timing, location, budget)
- Fetches and parses calendar pages from venues and event sites
- Integrates with existing memory system for preference persistence

## Changes

### New Agent: `agents/events/`
- `main.py` - Agent definition using `create_simple_agent()` with restricted tool access (fetch_web_content, memory tools only)
- `prompts.py` - Comprehensive system prompt including:
  - Event discovery workflow (check preferences → fetch sources → apply filters → present recommendations)
  - Preference learning schema with structured memory patterns
  - Calendar parsing guidance
  - Event presentation format

### Integration
- **API Server** (`agents/api/server.py`) - Added EventsAgent to registry, available at `/agents/events/message`
- **CLI Runner** (`bin/run-agent`) - Added "events" to agent registry, runnable via `uv run bin/run-agent events`

### Fixes
- **bin/run-agent** - Fixed module import by adding project root to `sys.path` (script now works as standalone executable)
- **docker-compose.dev.yml** - Removed obsolete `version` attribute (Docker Compose v2+ ignores it)

### Housekeeping
- Added `.claude.json` to `.gitignore`

## Usage

```bash
# Run via CLI
uv run bin/run-agent events

# Run as module
uv run python -m agents.events.main

# Via REST API
curl -X POST http://localhost:8080/agents/events/message \
  -H "Content-Type: application/json" \
  -d '{"message": "What jazz events are happening this weekend?"}'
```

## Test plan

- [ ] Verify agent starts: `uv run bin/run-agent events`
- [ ] Test preference saving: tell agent "I love jazz concerts"
- [ ] Test preference recall: ask for recommendations, verify jazz is boosted
- [ ] Test calendar fetching: provide a venue calendar URL
- [ ] Verify API endpoint works: POST to `/agents/events/message`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)