### PR TITLE
fix: remove path filters from Claude review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,8 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "**/*.py"
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -3,8 +3,6 @@ name: Claude Security Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "**/*.py"
 
 jobs:
   claude-security-review:


### PR DESCRIPTION
The path filters prevented workflows from running on PRs that only modified
files without .py extensions (like bin/run-agent). Removing the filters
ensures the workflows run on all PRs.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
