### PR TITLE
Enhance handle_tool_errors decorator with configurable options

### DIFF
--- a/packages/agent-framework/agent_framework/tools/fastmail.py
+++ b/packages/agent-framework/agent_framework/tools/fastmail.py
@@ -13,6 +13,8 @@ from typing import Any
 import httpx
 
 from ..core.config import settings
+from ..utils.errors import ServerError
+from ..utils.tool_decorators import handle_tool_errors
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +205,7 @@ def _format_mailbox(mailbox: dict[str, Any]) -> dict[str, Any]:
 # =============================================================================
 
 
+@handle_tool_errors(operation="list mailboxes")
 async def list_mailboxes(
     api_token: str | None = None,
 ) -> dict[str, Any]:
@@ -226,88 +229,62 @@ async def list_mailboxes(
     """
     logger.info("Listing FastMail mailboxes")
 
-    try:
-        client = _get_client(api_token)
-        await client._ensure_session()
+    client = _get_client(api_token)
+    await client._ensure_session()
 
-        response = await client._call(
+    response = await client._call(
+        [
             [
-                [
-                    "Mailbox/get",
-                    {
-                        "accountId": client.account_id,
-                        "properties": [
-                            "id",
-                            "name",
-                            "role",
-                            "parentId",
-                            "totalEmails",
-                            "unreadEmails",
-                            "totalThreads",
-                            "unreadThreads",
-                            "sortOrder",
-                            "isSubscribed",
-                        ],
-                    },
-                    "mailbox-list",
-                ]
+                "Mailbox/get",
+                {
+                    "accountId": client.account_id,
+                    "properties": [
+                        "id",
+                        "name",
+                        "role",
+                        "parentId",
+                        "totalEmails",
+                        "unreadEmails",
+                        "totalThreads",
+                        "unreadThreads",
+                        "sortOrder",
+                        "isSubscribed",
+                    ],
+                },
+                "mailbox-list",
             ]
-        )
+        ]
+    )
 
-        # Extract mailboxes from response
-        method_responses = response.get("methodResponses", [])
-        if not method_responses:
-            return {
-                "status": "error",
-                "message": "No response from JMAP server",
-            }
+    # Extract mailboxes from response
+    method_responses = response.get("methodResponses", [])
+    if not method_responses:
+        raise ServerError("No response from JMAP server")
 
-        result = method_responses[0]
-        if result[0] == "error":
-            return {
-                "status": "error",
-                "message": f"JMAP error: {result[1].get('description', 'Unknown error')}",
-            }
+    result = method_responses[0]
+    if result[0] == "error":
+        raise ServerError(f"JMAP error: {result[1].get('description', 'Unknown error')}")
 
-        mailboxes = result[1].get("list", [])
-        formatted = [_format_mailbox(m) for m in mailboxes]
+    mailboxes = result[1].get("list", [])
+    formatted = [_format_mailbox(m) for m in mailboxes]
 
-        # Sort by role priority then name
-        role_priority = {
-            "inbox": 0,
-            "drafts": 1,
-            "sent": 2,
-            "archive": 3,
-            "trash": 4,
-            "junk": 5,
-        }
-        formatted.sort(key=lambda m: (role_priority.get(m["role"], 99), m["name"]))
+    # Sort by role priority then name
+    role_priority = {
+        "inbox": 0,
+        "drafts": 1,
+        "sent": 2,
+        "archive": 3,
+        "trash": 4,
+        "junk": 5,
+    }
+    formatted.sort(key=lambda m: (role_priority.get(m["role"], 99), m["name"]))
 
-        logger.info(f"Found {len(formatted)} mailboxes")
-        return {
-            "status": "success",
-            "mailboxes": formatted,
-            "total_count": len(formatted),
-            "message": f"Found {len(formatted)} mailboxes",
-        }
-
-    except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error listing mailboxes: {e}")
-        if e.response.status_code == 401:
-            return {
-                "status": "error",
-                "message": "Authentication failed. Check your FastMail API token.",
-            }
-        return {
-            "status": "error",
-            "message": f"HTTP error: {e.response.status_code}",
-        }
-    except Exception as e:
-        logger.error(f"Error listing mailboxes: {e}")
-        return {
-            "status": "error",
-            "message": str(e),
-        }
+    logger.info(f"Found {len(formatted)} mailboxes")
+    return {
+        "mailboxes": formatted,
+        "total_count": len(formatted),
+        "message": f"Found {len(formatted)} mailboxes",
+    }
 
 
 async def get_emails(

--- a/packages/agent-framework/agent_framework/utils/__init__.py
+++ b/packages/agent-framework/agent_framework/utils/__init__.py
@@ -1,12 +1,19 @@
 """Utility functions and classes."""
 
-from .errors import AgentError, AuthenticationError, ToolExecutionError, ValidationError
+from .errors import (
+    AgentError,
+    AuthenticationError,
+    ServerError,
+    ToolExecutionError,
+    ValidationError,
+)
 from .tool_decorators import handle_tool_errors
 
 __all__ = [
     "AgentError",
-    "ValidationError",
     "AuthenticationError",
+    "ServerError",
     "ToolExecutionError",
+    "ValidationError",
     "handle_tool_errors",
 ]

--- a/packages/agent-framework/agent_framework/utils/errors.py
+++ b/packages/agent-framework/agent_framework/utils/errors.py
@@ -25,6 +25,16 @@ class ToolExecutionError(AgentError):
     pass
 
 
+class ServerError(AgentError):
+    """Raised when a server or protocol error occurs.
+
+    Use this for errors from external services (API errors, protocol violations,
+    unexpected responses) as opposed to ValidationError which is for input validation.
+    """
+
+    pass
+
+
 class SecurityError(AgentError):
     """Base exception for security-related errors."""
 

--- a/packages/agent-framework/agent_framework/utils/tool_decorators.py
+++ b/packages/agent-framework/agent_framework/utils/tool_decorators.py
@@ -1,85 +1,336 @@
-"""Decorators for standardizing tool error handling."""
+"""Decorators for standardizing tool error handling.
+
+This module provides the `handle_tool_errors` decorator for consistent error handling
+across all MCP tools. It catches common exceptions and returns a standardized error
+format that agents can easily parse and respond to.
+
+Usage:
+    # Basic usage (no parameters)
+    @handle_tool_errors
+    async def my_tool(param: str) -> dict[str, Any]:
+        result = await do_something(param)
+        return {"data": result}
+
+    # With custom operation name for clearer logs
+    @handle_tool_errors(operation="fetch user profile")
+    async def get_user(user_id: str) -> dict[str, Any]:
+        ...
+
+    # With traceback for debugging
+    @handle_tool_errors(include_traceback=True)
+    async def debug_tool() -> dict[str, Any]:
+        ...
+"""
 
 import functools
 import logging
+import traceback
 from collections.abc import Callable
-from typing import Any
+from typing import Any, overload
 
 import httpx
+
+from .errors import (
+    AgentError,
+    AuthenticationError,
+    ConfigurationError,
+    ServerError,
+    ValidationError,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def handle_tool_errors[F: Callable[..., Any]](func: F) -> F:
+def _build_error_response(
+    message: str,
+    error_type: str,
+    *,
+    include_traceback: bool = False,
+    status_code: int | None = None,
+) -> dict[str, Any]:
+    """Build a standardized error response dictionary.
+
+    Args:
+        message: Human-readable error message
+        error_type: Error classification (e.g., "ValidationError", "HTTPError")
+        include_traceback: Whether to include full traceback in response
+        status_code: HTTP status code if applicable
+
+    Returns:
+        Standardized error dictionary with status, message, and error_type
+    """
+    response: dict[str, Any] = {
+        "status": "error",
+        "message": message,
+        "error_type": error_type,
+    }
+    if status_code is not None:
+        response["status_code"] = status_code
+    if include_traceback:
+        response["traceback"] = traceback.format_exc()
+    return response
+
+
+def _handle_exception(
+    e: Exception,
+    operation: str,
+    include_traceback: bool,
+) -> dict[str, Any]:
+    """Handle an exception and return appropriate error response.
+
+    Args:
+        e: The caught exception
+        operation: Operation name for logging context
+        include_traceback: Whether to include traceback in response
+
+    Returns:
+        Standardized error dictionary
+    """
+    # HTTP errors with specific status code handling
+    if isinstance(e, httpx.HTTPStatusError):
+        status = e.response.status_code
+        logger.error(f"{operation} HTTP {status}: {e}")
+
+        # Map common HTTP status codes to semantic error types
+        http_error_map: dict[int, tuple[str, str]] = {
+            400: ("Bad request", "BadRequestError"),
+            401: ("Authentication required", "AuthenticationError"),
+            403: ("Access forbidden", "ForbiddenError"),
+            404: ("Resource not found", "NotFoundError"),
+            409: ("Conflict - resource already exists", "ConflictError"),
+            422: ("Validation failed", "ValidationError"),
+            429: ("Rate limit exceeded", "RateLimitError"),
+            500: ("Internal server error", "ServerError"),
+            502: ("Bad gateway", "GatewayError"),
+            503: ("Service unavailable", "ServiceUnavailableError"),
+            504: ("Gateway timeout", "TimeoutError"),
+        }
+
+        if status in http_error_map:
+            message, error_type = http_error_map[status]
+            return _build_error_response(
+                message,
+                error_type,
+                include_traceback=include_traceback,
+                status_code=status,
+            )
+
+        return _build_error_response(
+            f"HTTP {status}: {e}",
+            "HTTPError",
+            include_traceback=include_traceback,
+            status_code=status,
+        )
+
+    # Network/connection errors
+    if isinstance(e, httpx.RequestError):
+        logger.error(f"{operation} request failed: {e}")
+        return _build_error_response(
+            f"Request failed: {e}",
+            "RequestError",
+            include_traceback=include_traceback,
+        )
+
+    # Timeout errors (async operations)
+    # Note: asyncio.TimeoutError is an alias for TimeoutError in Python 3.11+
+    if isinstance(e, TimeoutError):
+        logger.error(f"{operation} timed out: {e}")
+        return _build_error_response(
+            f"Operation timed out: {e}",
+            "TimeoutError",
+            include_traceback=include_traceback,
+        )
+
+    # File system errors
+    if isinstance(e, FileNotFoundError):
+        logger.error(f"{operation} file not found: {e}")
+        return _build_error_response(
+            f"File not found: {e.filename if e.filename else e}",
+            "NotFoundError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, FileExistsError):
+        logger.error(f"{operation} file exists: {e}")
+        return _build_error_response(
+            f"File already exists: {e.filename if e.filename else e}",
+            "ConflictError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, PermissionError):
+        logger.error(f"{operation} permission denied: {e}")
+        return _build_error_response(
+            f"Permission denied: {e}",
+            "ForbiddenError",
+            include_traceback=include_traceback,
+        )
+
+    # Framework-specific errors
+    if isinstance(e, ValidationError):
+        logger.error(f"{operation} validation error: {e}")
+        return _build_error_response(
+            str(e),
+            "ValidationError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, AuthenticationError):
+        logger.error(f"{operation} authentication error: {e}")
+        return _build_error_response(
+            str(e),
+            "AuthenticationError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, ServerError):
+        logger.error(f"{operation} server error: {e}")
+        return _build_error_response(
+            str(e),
+            "ServerError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, ConfigurationError):
+        logger.error(f"{operation} configuration error: {e}")
+        return _build_error_response(
+            str(e),
+            "ConfigurationError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, AgentError):
+        logger.error(f"{operation} agent error: {e}")
+        return _build_error_response(
+            str(e),
+            type(e).__name__,
+            include_traceback=include_traceback,
+        )
+
+    # Built-in validation errors
+    if isinstance(e, ValueError):
+        logger.error(f"{operation} validation error: {e}")
+        return _build_error_response(
+            str(e),
+            "ValidationError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, TypeError):
+        logger.error(f"{operation} type error: {e}")
+        return _build_error_response(
+            str(e),
+            "TypeError",
+            include_traceback=include_traceback,
+        )
+
+    if isinstance(e, KeyError):
+        logger.error(f"{operation} key error: {e}")
+        return _build_error_response(
+            f"Missing key: {e}",
+            "KeyError",
+            include_traceback=include_traceback,
+        )
+
+    # Catch-all for unexpected errors
+    logger.exception(f"{operation} unexpected error: {e}")
+    return _build_error_response(
+        f"Unexpected error: {e}",
+        type(e).__name__,
+        include_traceback=include_traceback,
+    )
+
+
+@overload
+def handle_tool_errors[F: Callable[..., Any]](func: F) -> F: ...
+
+
+@overload
+def handle_tool_errors(
+    *,
+    operation: str | None = None,
+    include_traceback: bool = False,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
+
+
+def handle_tool_errors[F: Callable[..., Any]](
+    func: F | None = None,
+    *,
+    operation: str | None = None,
+    include_traceback: bool = False,
+) -> F | Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Standardize error handling for async tool functions.
 
-    Catches common exceptions and returns consistent error format:
+    Catches common exceptions and returns a consistent error format:
     {"status": "error", "message": "...", "error_type": "..."}
 
     On success, adds "status": "success" to the result if not already present.
 
-    Example:
+    Can be used with or without arguments:
+
         @handle_tool_errors
         async def my_tool(param: str) -> dict[str, Any]:
-            # If this raises, caller gets {"status": "error", "message": "...", ...}
-            result = await do_something(param)
-            return {"data": result}
+            ...
+
+        @handle_tool_errors(operation="fetch emails")
+        async def get_emails() -> dict[str, Any]:
+            ...
+
+    Args:
+        func: The function to decorate (when used without parentheses)
+        operation: Custom operation name for log messages. Defaults to function name.
+            Use a descriptive verb phrase like "fetch user profile" or "send email".
+        include_traceback: Include full stack trace in error response. Useful for
+            debugging but should be False in production. Default: False.
+
+    Returns:
+        Decorated function that catches exceptions and returns error dictionaries.
+
+    Error Types Handled:
+        - httpx.HTTPStatusError: HTTP errors with semantic status code mapping
+        - httpx.RequestError: Network/connection failures
+        - TimeoutError: Async operation timeouts
+        - FileNotFoundError: File system errors (maps to NotFoundError)
+        - FileExistsError: File conflicts (maps to ConflictError)
+        - PermissionError: Access denied (maps to ForbiddenError)
+        - ValidationError: Input validation failures (framework or ValueError)
+        - AuthenticationError: Auth failures
+        - ConfigurationError: Missing/invalid configuration
+        - AgentError: Base framework errors
+        - TypeError, KeyError: Programming errors
+        - Exception: Catch-all for unexpected errors
+
+    Example:
+        @handle_tool_errors(operation="list mailboxes")
+        async def list_mailboxes(api_token: str | None = None) -> dict[str, Any]:
+            client = get_client(api_token)
+            mailboxes = await client.list_mailboxes()
+            return {"mailboxes": mailboxes, "count": len(mailboxes)}
+
+        # On success: {"status": "success", "mailboxes": [...], "count": 5}
+        # On 401 error: {"status": "error", "message": "Authentication required",
+        #                "error_type": "AuthenticationError", "status_code": 401}
+        # On ValueError: {"status": "error", "message": "Invalid input",
+        #                 "error_type": "ValidationError"}
     """
 
-    @functools.wraps(func)
-    async def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        tool_name = func.__name__
-        try:
-            result = await func(*args, **kwargs)
-            if isinstance(result, dict) and "status" not in result:
-                result["status"] = "success"
-            return result
-        except httpx.HTTPStatusError as e:
-            status = e.response.status_code
-            logger.error(f"Tool {tool_name} HTTP {status}: {e}")
-            if status == 401:
-                return {
-                    "status": "error",
-                    "message": "Authentication required",
-                    "error_type": "AuthenticationError",
-                }
-            if status == 403:
-                return {
-                    "status": "error",
-                    "message": "Access forbidden",
-                    "error_type": "ForbiddenError",
-                }
-            if status == 404:
-                return {
-                    "status": "error",
-                    "message": "Resource not found",
-                    "error_type": "NotFoundError",
-                }
-            return {
-                "status": "error",
-                "message": f"HTTP {status}: {e}",
-                "error_type": "HTTPError",
-            }
-        except httpx.RequestError as e:
-            logger.error(f"Tool {tool_name} request failed: {e}")
-            return {
-                "status": "error",
-                "message": f"Request failed: {e}",
-                "error_type": "RequestError",
-            }
-        except ValueError as e:
-            logger.error(f"Tool {tool_name} validation error: {e}")
-            return {
-                "status": "error",
-                "message": str(e),
-                "error_type": "ValidationError",
-            }
-        except Exception as e:
-            logger.exception(f"Tool {tool_name} unexpected error: {e}")
-            return {
-                "status": "error",
-                "message": f"Unexpected error: {e}",
-                "error_type": type(e).__name__,
-            }
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        op_name = operation or fn.__name__
 
-    return wrapper  # type: ignore[return-value]
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            try:
+                result = await fn(*args, **kwargs)
+                # Auto-add success status if missing
+                if isinstance(result, dict) and "status" not in result:
+                    result["status"] = "success"
+                return result
+            except Exception as e:
+                return _handle_exception(e, op_name, include_traceback)
+
+        return wrapper
+
+    # Support both @handle_tool_errors and @handle_tool_errors(...)
+    if func is not None:
+        return decorator(func)  # type: ignore[return-value]
+    return decorator

--- a/packages/agent-framework/tests/test_fastmail.py
+++ b/packages/agent-framework/tests/test_fastmail.py
@@ -193,7 +193,8 @@ class TestListMailboxes:
             result = await list_mailboxes()
 
             assert result["status"] == "error"
-            assert "Authentication failed" in result["message"]
+            assert result["error_type"] == "AuthenticationError"
+            assert result["status_code"] == 401
 
 
 class TestSendEmail:
@@ -374,4 +375,5 @@ class TestErrorHandling:
             result = await list_mailboxes()
 
             assert result["status"] == "error"
-            assert "403" in result["message"]
+            assert result["error_type"] == "ForbiddenError"
+            assert result["status_code"] == 403

--- a/tests/unit/test_tool_decorators.py
+++ b/tests/unit/test_tool_decorators.py
@@ -2,6 +2,12 @@
 
 import httpx
 import pytest
+from agent_framework.utils.errors import (
+    AuthenticationError,
+    ConfigurationError,
+    ServerError,
+    ValidationError,
+)
 from agent_framework.utils.tool_decorators import handle_tool_errors
 
 
@@ -90,8 +96,8 @@ class TestHandleToolErrors:
         assert "not found" in result["message"].lower()
 
     @pytest.mark.asyncio
-    async def test_http_500_returns_http_error(self):
-        """HTTP 500 should be returned as HTTPError with status code."""
+    async def test_http_500_returns_server_error(self):
+        """HTTP 500 should be returned as ServerError with status code."""
 
         @handle_tool_errors
         async def my_tool() -> dict:
@@ -100,8 +106,9 @@ class TestHandleToolErrors:
 
         result = await my_tool()
         assert result["status"] == "error"
-        assert result["error_type"] == "HTTPError"
-        assert "500" in result["message"]
+        assert result["error_type"] == "ServerError"
+        assert result["status_code"] == 500
+        assert "server error" in result["message"].lower()
 
     @pytest.mark.asyncio
     async def test_request_error_returns_request_error(self):
@@ -163,3 +170,296 @@ class TestHandleToolErrors:
         assert result["b"] == "hello"
         assert result["c"] is True
         assert result["status"] == "success"
+
+
+class TestHandleToolErrorsWithParameters:
+    """Tests for handle_tool_errors decorator with parameters."""
+
+    @pytest.mark.asyncio
+    async def test_custom_operation_name(self):
+        """Custom operation name should be used in error context."""
+
+        @handle_tool_errors(operation="fetch user emails")
+        async def get_emails() -> dict:
+            raise ValueError("Invalid mailbox")
+
+        result = await get_emails()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ValidationError"
+        # The operation name is used in logging, not in the response
+        assert "Invalid mailbox" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_include_traceback_false_by_default(self):
+        """Traceback should not be included by default."""
+
+        @handle_tool_errors
+        async def my_tool() -> dict:
+            raise RuntimeError("Boom")
+
+        result = await my_tool()
+        assert "traceback" not in result
+
+    @pytest.mark.asyncio
+    async def test_include_traceback_true(self):
+        """Traceback should be included when requested."""
+
+        @handle_tool_errors(include_traceback=True)
+        async def my_tool() -> dict:
+            raise RuntimeError("Boom")
+
+        result = await my_tool()
+        assert "traceback" in result
+        assert "RuntimeError" in result["traceback"]
+        assert "Boom" in result["traceback"]
+
+    @pytest.mark.asyncio
+    async def test_with_all_parameters(self):
+        """Both operation and include_traceback can be used together."""
+
+        @handle_tool_errors(operation="process data", include_traceback=True)
+        async def process() -> dict:
+            raise ValueError("Bad data")
+
+        result = await process()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ValidationError"
+        assert "traceback" in result
+
+
+class TestFileSystemErrors:
+    """Tests for file system error handling."""
+
+    @pytest.mark.asyncio
+    async def test_file_not_found_error(self):
+        """FileNotFoundError should be returned as NotFoundError."""
+
+        @handle_tool_errors
+        async def read_file() -> dict:
+            raise FileNotFoundError(2, "No such file", "/path/to/file.txt")
+
+        result = await read_file()
+        assert result["status"] == "error"
+        assert result["error_type"] == "NotFoundError"
+        assert "/path/to/file.txt" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_file_exists_error(self):
+        """FileExistsError should be returned as ConflictError."""
+
+        @handle_tool_errors
+        async def create_file() -> dict:
+            raise FileExistsError(17, "File exists", "/path/to/file.txt")
+
+        result = await create_file()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ConflictError"
+        assert "/path/to/file.txt" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_permission_error(self):
+        """PermissionError should be returned as ForbiddenError."""
+
+        @handle_tool_errors
+        async def write_file() -> dict:
+            raise PermissionError("Cannot write to /etc/passwd")
+
+        result = await write_file()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ForbiddenError"
+        assert "Permission denied" in result["message"]
+
+
+class TestTimeoutErrors:
+    """Tests for timeout error handling."""
+
+    @pytest.mark.asyncio
+    async def test_builtin_timeout_error(self):
+        """Built-in TimeoutError should be handled."""
+
+        @handle_tool_errors
+        async def slow_operation() -> dict:
+            raise TimeoutError("Operation timed out after 30s")
+
+        result = await slow_operation()
+        assert result["status"] == "error"
+        assert result["error_type"] == "TimeoutError"
+        assert "timed out" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_asyncio_timeout_error(self):
+        """asyncio.TimeoutError should be handled."""
+
+        @handle_tool_errors
+        async def async_operation() -> dict:
+            raise TimeoutError("Async timeout")
+
+        result = await async_operation()
+        assert result["status"] == "error"
+        assert result["error_type"] == "TimeoutError"
+
+
+class TestFrameworkErrors:
+    """Tests for framework-specific error handling."""
+
+    @pytest.mark.asyncio
+    async def test_framework_validation_error(self):
+        """Framework ValidationError should be handled."""
+
+        @handle_tool_errors
+        async def validate() -> dict:
+            raise ValidationError("Input validation failed")
+
+        result = await validate()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ValidationError"
+        assert "Input validation failed" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_framework_authentication_error(self):
+        """Framework AuthenticationError should be handled."""
+
+        @handle_tool_errors
+        async def authenticate() -> dict:
+            raise AuthenticationError("Token expired")
+
+        result = await authenticate()
+        assert result["status"] == "error"
+        assert result["error_type"] == "AuthenticationError"
+        assert "Token expired" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_framework_configuration_error(self):
+        """Framework ConfigurationError should be handled."""
+
+        @handle_tool_errors
+        async def configure() -> dict:
+            raise ConfigurationError("Missing API key")
+
+        result = await configure()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ConfigurationError"
+        assert "Missing API key" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_framework_server_error(self):
+        """Framework ServerError should be handled."""
+
+        @handle_tool_errors
+        async def call_api() -> dict:
+            raise ServerError("JMAP error: Invalid method")
+
+        result = await call_api()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ServerError"
+        assert "JMAP error" in result["message"]
+
+
+class TestAdditionalHTTPStatusCodes:
+    """Tests for additional HTTP status code handling."""
+
+    @pytest.mark.asyncio
+    async def test_http_400_returns_bad_request(self):
+        """HTTP 400 should be returned as BadRequestError."""
+
+        @handle_tool_errors
+        async def my_tool() -> dict:
+            response = httpx.Response(400, request=httpx.Request("POST", "http://test"))
+            raise httpx.HTTPStatusError("Bad Request", request=response.request, response=response)
+
+        result = await my_tool()
+        assert result["status"] == "error"
+        assert result["error_type"] == "BadRequestError"
+        assert result["status_code"] == 400
+
+    @pytest.mark.asyncio
+    async def test_http_409_returns_conflict(self):
+        """HTTP 409 should be returned as ConflictError."""
+
+        @handle_tool_errors
+        async def my_tool() -> dict:
+            response = httpx.Response(409, request=httpx.Request("PUT", "http://test"))
+            raise httpx.HTTPStatusError("Conflict", request=response.request, response=response)
+
+        result = await my_tool()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ConflictError"
+        assert result["status_code"] == 409
+
+    @pytest.mark.asyncio
+    async def test_http_429_returns_rate_limit(self):
+        """HTTP 429 should be returned as RateLimitError."""
+
+        @handle_tool_errors
+        async def my_tool() -> dict:
+            response = httpx.Response(429, request=httpx.Request("GET", "http://test"))
+            raise httpx.HTTPStatusError(
+                "Too Many Requests", request=response.request, response=response
+            )
+
+        result = await my_tool()
+        assert result["status"] == "error"
+        assert result["error_type"] == "RateLimitError"
+        assert result["status_code"] == 429
+
+    @pytest.mark.asyncio
+    async def test_http_503_returns_service_unavailable(self):
+        """HTTP 503 should be returned as ServiceUnavailableError."""
+
+        @handle_tool_errors
+        async def my_tool() -> dict:
+            response = httpx.Response(503, request=httpx.Request("GET", "http://test"))
+            raise httpx.HTTPStatusError(
+                "Service Unavailable", request=response.request, response=response
+            )
+
+        result = await my_tool()
+        assert result["status"] == "error"
+        assert result["error_type"] == "ServiceUnavailableError"
+        assert result["status_code"] == 503
+
+    @pytest.mark.asyncio
+    async def test_unmapped_http_status_returns_generic(self):
+        """Unmapped HTTP status codes should return HTTPError with status code."""
+
+        @handle_tool_errors
+        async def my_tool() -> dict:
+            response = httpx.Response(418, request=httpx.Request("GET", "http://test"))
+            raise httpx.HTTPStatusError("I'm a teapot", request=response.request, response=response)
+
+        result = await my_tool()
+        assert result["status"] == "error"
+        assert result["error_type"] == "HTTPError"
+        assert result["status_code"] == 418
+        assert "418" in result["message"]
+
+
+class TestKeyAndTypeErrors:
+    """Tests for KeyError and TypeError handling."""
+
+    @pytest.mark.asyncio
+    async def test_key_error(self):
+        """KeyError should be handled with descriptive message."""
+
+        @handle_tool_errors
+        async def access_dict() -> dict:
+            data: dict = {}
+            return {"value": data["missing_key"]}
+
+        result = await access_dict()
+        assert result["status"] == "error"
+        assert result["error_type"] == "KeyError"
+        assert "missing_key" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_type_error(self):
+        """TypeError should be handled."""
+
+        @handle_tool_errors
+        async def wrong_type() -> dict:
+            raise TypeError("Expected str, got int")
+
+        result = await wrong_type()
+        assert result["status"] == "error"
+        assert result["error_type"] == "TypeError"
+        assert "Expected str" in result["message"]


### PR DESCRIPTION
## Summary

- Enhanced `handle_tool_errors` decorator with optional parameters for operation name and traceback inclusion
- Added support for 15+ error types with semantic classification (HTTP codes, timeouts, file system, framework errors)
- Added `ServerError` exception for protocol/server errors (distinct from `ValidationError` for input validation)
- Applied decorator to `list_mailboxes` as example transformation, reducing ~23 lines of error handling to 1 line
- Added 20 new unit tests (32 total) covering all error scenarios

## Changes

**`packages/agent-framework/agent_framework/utils/errors.py`**
- Added `ServerError` exception for protocol/server errors (JMAP errors, API failures, etc.)

**`packages/agent-framework/agent_framework/utils/tool_decorators.py`**
- Added `operation` parameter for custom log context
- Added `include_traceback` parameter for debugging
- Support both `@handle_tool_errors` and `@handle_tool_errors(...)` syntax
- Handle HTTP status codes: 400, 401, 403, 404, 409, 422, 429, 500, 502, 503, 504
- Handle file system errors: FileNotFoundError, FileExistsError, PermissionError
- Handle timeouts: TimeoutError (simplified - asyncio.TimeoutError is an alias in Python 3.11+)
- Handle framework errors: ValidationError, AuthenticationError, ConfigurationError, ServerError
- Include `status_code` field in HTTP error responses

**`packages/agent-framework/agent_framework/tools/fastmail.py`**
- Applied decorator to `list_mailboxes` as example transformation
- Use `ServerError` instead of `ValueError` for JMAP protocol errors

**`tests/unit/test_tool_decorators.py`**
- Added 20 new tests covering all error types (32 total)

**`packages/agent-framework/tests/test_fastmail.py`**
- Updated assertions to use standardized `error_type` field

## Test plan

- [x] All 32 decorator tests pass
- [x] All 18 fastmail tests pass  
- [x] Pre-commit hooks pass (ruff, pyright, pytest, bandit)

🤖 Generated with [Claude Code](https://claude.ai/code)