### PR TITLE
Add PUBLISH phase: push branch and create PR after review

### DIFF
--- a/agents/orchestrator/models.py
+++ b/agents/orchestrator/models.py
@@ -131,6 +131,7 @@ class Phase(str, Enum):
     PLAN = "plan"
     EXECUTE = "execute"
     REVIEW = "review"
+    PUBLISH = "publish"
     HUMAN_GATE = "human_gate"
     COMPLETE = "complete"
     FAILED = "failed"
@@ -208,6 +209,7 @@ class Task:
     # Results
     worker_output: str | None = None
     review_results: list[ReviewResult] = field(default_factory=list)
+    pr_url: str | None = None
     error: str | None = None
 
     # Metadata

--- a/agents/orchestrator/state_machine.py
+++ b/agents/orchestrator/state_machine.py
@@ -3,10 +3,10 @@
 The orchestrator is a lightweight control plane that drives work through a
 deterministic state machine:
 
-    INGEST -> PLAN -> EXECUTE -> REVIEW -> COMPLETE
-                                   |          |
-                                   v          v
-                              HUMAN_GATE   FAILED
+    INGEST -> PLAN -> EXECUTE -> REVIEW -> PUBLISH -> COMPLETE
+                                   |          |          |
+                                   v          v          v
+                              HUMAN_GATE   FAILED     FAILED
                                    |
                                    v
                                 COMPLETE
@@ -40,7 +40,7 @@ from .models import (
 )
 from .planner import PlanningError, plan_task
 from .reviewers import run_code_review, run_security_review
-from .workers import dispatch_worker, ensure_workspace, get_workspace_diff
+from .workers import dispatch_worker, ensure_workspace, get_workspace_diff, push_and_create_pr
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +207,7 @@ class Orchestrator:
     async def _process_task(self, task: Task) -> None:
         """Process a single task through the full pipeline.
 
-        Pipeline: INGEST -> PLAN -> EXECUTE -> REVIEW -> COMPLETE/HUMAN_GATE
+        Pipeline: INGEST -> PLAN -> EXECUTE -> REVIEW -> PUBLISH -> COMPLETE/HUMAN_GATE
         """
         # INGEST: Validate and prepare
         async with self._lock:
@@ -270,6 +270,12 @@ class Orchestrator:
             # Check if we should create remediation tasks
             await self._handle_review_failure(task)
             return
+
+        # PUBLISH: Push branch and create PR (only for tasks with changes)
+        if task.branch_name and task.workspace_name:
+            async with self._lock:
+                self.state.phase = Phase.PUBLISH
+            await self._publish_task(task)
 
         # COMPLETE or HUMAN_GATE based on autonomy tier
         await self._finalize_task(task)
@@ -397,6 +403,34 @@ class Orchestrator:
             )
 
         return all_passed
+
+    async def _publish_task(self, task: Task) -> None:
+        """Push branch and create a PR for a completed task.
+
+        Best-effort: if push or PR creation fails, the task still proceeds
+        to finalization. The code is committed locally regardless.
+        """
+        try:
+            # Get diff summary for the PR body
+            diff = await get_workspace_diff(
+                task.workspace_name,  # type: ignore[arg-type]
+                task.branch_name,  # type: ignore[arg-type]
+                self.config,
+            )
+            # Use a short stat-like summary, not the full diff
+            diff_lines = diff.strip().splitlines()
+            diff_summary = "\n".join(diff_lines[:50]) if diff_lines else ""
+
+            pr_url = await push_and_create_pr(task, self.config, diff_summary=diff_summary)
+            task.pr_url = pr_url
+
+            if pr_url:
+                logger.info(f"Task {task.id} published: {pr_url}")
+            else:
+                logger.warning(f"Task {task.id}: push/PR creation returned no URL")
+        except Exception as e:
+            logger.error(f"Publish failed for task {task.id}: {e}")
+            # Non-fatal: task proceeds to finalization
 
     async def _handle_review_failure(self, task: Task) -> None:
         """Handle a task that failed review by creating remediation tasks.

--- a/agents/orchestrator/workers.py
+++ b/agents/orchestrator/workers.py
@@ -244,6 +244,100 @@ async def dispatch_worker(
     )
 
 
+async def push_and_create_pr(
+    task: Task,
+    config: OrchestratorConfig,
+    diff_summary: str = "",
+) -> str | None:
+    """Push branch and create a PR via Claude Code.
+
+    This is a mechanical step — Claude Code runs git push and gh pr create.
+    Best-effort: returns the PR URL on success, None on failure.
+
+    Args:
+        task: The task with branch_name and workspace_name set.
+        config: Orchestrator configuration (provides base_branch).
+        diff_summary: Optional diff summary to include in the PR body.
+
+    Returns:
+        The PR URL, or None if push/PR creation failed.
+    """
+    if not task.workspace_name or not task.branch_name:
+        logger.warning(f"Task {task.id} missing workspace/branch for publish")
+        return None
+
+    validate_workspace_name(task.workspace_name)
+    validate_git_ref(task.branch_name, "branch name for publish")
+
+    safe_title = _sanitise_task_text(task.title, max_length=200)
+    safe_description = _sanitise_task_text(task.description, max_length=1000)
+
+    # Build PR body content for the prompt
+    body_diff = diff_summary[:2000] if diff_summary else ""
+    body_parts = [safe_description]
+
+    # Link back to the originating task
+    if task.external_id:
+        task_ref = f"Task: `{task.external_id}`"
+        taskmanager_url = os.environ.get("TASKMANAGER_URL", "").rstrip("/")
+        if taskmanager_url:
+            task_ref = f"Task: [{task.external_id}]({taskmanager_url}/task/{task.external_id})"
+        body_parts.append(task_ref)
+
+    if body_diff:
+        body_parts.append(f"## Changes\n\n```\n{body_diff}\n```")
+    pr_body = "\n\n".join(body_parts)
+
+    prompt = (
+        f"Push the current branch and create a pull request. "
+        f"Run these commands:\n\n"
+        f"1. `git push -u origin {shlex.quote(task.branch_name)}`\n"
+        f"2. Create a PR with `gh pr create`:\n"
+        f"   - Base branch: `{config.base_branch}`\n"
+        f"   - Title: {safe_title}\n\n"
+        f"Use the following as the PR body:\n\n{pr_body}\n\n"
+        f"If push or PR creation fails, report the error. "
+        f"Do NOT attempt to fix code or make additional commits."
+    )
+
+    logger.info(
+        f"Publishing task {task.id}: pushing {task.branch_name} "
+        f"and creating PR in workspace {task.workspace_name}"
+    )
+
+    result = await run_claude_code(
+        folder_name=task.workspace_name,
+        command=prompt,
+        timeout=120,
+        max_turns=5,
+        model=config.worker_model,
+    )
+
+    output = result.get("output", "")
+    if not result.get("success", False):
+        error = result.get("error_output") or result.get("error", "unknown")
+        logger.warning(f"Publish failed for task {task.id}: {error}")
+        return None
+
+    # Extract PR URL from output
+    pr_url = _extract_pr_url(output)
+    if pr_url:
+        logger.info(f"PR created for task {task.id}: {pr_url}")
+    else:
+        logger.warning(f"Push succeeded but no PR URL found in output for task {task.id}")
+
+    return pr_url
+
+
+def _extract_pr_url(output: str) -> str | None:
+    """Extract a GitHub PR URL from Claude Code output.
+
+    Looks for https://github.com/.../ pull/N patterns.
+    """
+    match = re.search(r"https://github\.com/[^\s\"'<>]+/pull/\d+", output)
+    return match.group(0) if match else None
+
+
 async def get_workspace_diff(
     workspace_name: str,
     branch_name: str,
@@ -332,7 +426,7 @@ async def get_workspace_diff(
         proc = await asyncio.create_subprocess_exec(
             "git",
             "diff",
-            "4b825dc642cb6eb9a060e54bf899d8e3b71d8631",
+            "4b825dc642cb6eb9a060e54bf899d8e3b71d8631",  # pragma: allowlist secret  # noqa: git empty tree SHA
             "HEAD",
             "--",
             cwd=str(workspace_path),

--- a/agents/task_queue/repo_map.json
+++ b/agents/task_queue/repo_map.json
@@ -1,0 +1,6 @@
+{
+  "agents": "git@github.com:brooksmcmillin/agents.git",
+  "task manager": "git@github.com:brooksmcmillin/taskmanager.git",
+  "taskmanager": "git@github.com:brooksmcmillin/taskmanager.git",
+  "chasm": "git@github.com:brooksmcmillin/chasm.git"
+}

--- a/agents/task_queue/runner.py
+++ b/agents/task_queue/runner.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 from datetime import date
+from pathlib import Path
 
 from agent_framework.tools import send_slack_message
 
@@ -50,8 +51,8 @@ logger = logging.getLogger(__name__)
 #    call.  This is a structured API field, not free-form comment text.
 #  - _AGENT_NOTE: Content passed to add_agent_note MCP calls.
 # ---------------------------------------------------------------------------
-COMMENT_MAX_LENGTH = 1000
-_OUTPUT_PREVIEW = 800
+COMMENT_MAX_LENGTH = 2000
+_OUTPUT_PREVIEW = 1800
 _ERROR_PREVIEW = 300
 _BLOCKING_REASON = 200
 _AGENT_NOTE = 500
@@ -88,6 +89,9 @@ class TaskQueueRunner(BatchAgent):
         6. Send batch notification
     """
 
+    _repo_map: dict[str, str] = {}
+    _repo_map_loaded: bool = False
+
     def __init__(self, config: TaskQueueConfig | None = None) -> None:
         self.config = config or TaskQueueConfig()
         super().__init__(mcp_url=self.config.mcp_url)
@@ -96,6 +100,68 @@ class TaskQueueRunner(BatchAgent):
 
     def get_name(self) -> str:
         return "TaskQueueRunner"
+
+    @classmethod
+    def _load_repo_map(cls) -> dict[str, str]:
+        """Load and cache the category-to-repo-URL mapping from repo_map.json.
+
+        Keys are normalized to lowercase for case-insensitive lookup.
+        """
+        if not cls._repo_map_loaded:
+            map_path = Path(__file__).parent / "repo_map.json"
+            try:
+                raw = json.loads(map_path.read_text())
+                cls._repo_map = {k.lower(): v for k, v in raw.items()}
+            except (FileNotFoundError, json.JSONDecodeError) as e:
+                logger.warning(f"Failed to load repo_map.json: {e}")
+                cls._repo_map = {}
+            cls._repo_map_loaded = True
+        return cls._repo_map
+
+    async def _resolve_repo_url(self, task: dict) -> str | None:
+        """Resolve a git repo URL for a task based on its category.
+
+        Checks the task's category against repo_map.json (case-insensitive),
+        then falls back to the parent task's category, then to the CLI --repo flag.
+        """
+        repo_map = self._load_repo_map()
+
+        def _lookup(category: str) -> str | None:
+            key = category.strip().lower()
+            return repo_map.get(key)
+
+        # Check task category
+        category = task.get("category") or ""
+        if category:
+            url = _lookup(category)
+            if url:
+                logger.debug(f"Resolved repo from task category '{category}'")
+                return url
+            logger.info(f"Category '{category}' not in repo_map")
+
+        # Check parent task category
+        parent_id = task.get("parent_id")
+        if parent_id:
+            try:
+                result = await self.call_tool("get_task", {"task_id": parent_id})
+                data = json.loads(result) if isinstance(result, str) else result
+                parent_task = data.get("task", data)
+                parent_category = parent_task.get("category") or ""
+                if parent_category:
+                    url = _lookup(parent_category)
+                    if url:
+                        logger.debug(f"Resolved repo from parent category '{parent_category}'")
+                        return url
+                    logger.debug(f"Parent category '{parent_category}' not in repo_map")
+            except Exception as e:
+                logger.debug(f"Failed to fetch parent task {parent_id}: {e}")
+
+        # Fall back to CLI --repo flag
+        if self.config.git_repo_url:
+            return self.config.git_repo_url
+
+        logger.info(f"No repo resolved for task {task.get('id', '?')} (category='{category}')")
+        return None
 
     async def _add_comment(self, task_id: str, content: str) -> None:
         """Add a comment to a task, logging failures without raising."""
@@ -311,8 +377,12 @@ class TaskQueueRunner(BatchAgent):
         # Skip if task already has subtasks (previously decomposed)
         existing_subtasks = task.get("subtasks") or []
         if existing_subtasks:
-            subtask_titles = [s.get("title", "") for s in existing_subtasks[:5]]
-            logger.info(f"Skipping {task_id}: already has {len(existing_subtasks)} subtasks")
+            subtask_info = [
+                f"{s.get('id', '?')}: {s.get('title', '')}" for s in existing_subtasks[:5]
+            ]
+            logger.info(
+                f"Skipping {task_id}: already has {len(existing_subtasks)} subtasks: {subtask_info}"
+            )
             self.report.tasks_processed.append(
                 ProcessedTask(
                     external_id=task_id,
@@ -320,7 +390,7 @@ class TaskQueueRunner(BatchAgent):
                     triage_verdict=TriageVerdict.SKIP_ALREADY_PROCESSING,
                     confidence=1.0,
                     outcome="skipped",
-                    notes=f"Already decomposed into {len(existing_subtasks)} subtasks: {subtask_titles}",
+                    notes=f"Already decomposed into {len(existing_subtasks)} subtasks: {subtask_info}",
                 )
             )
             self.context.skipped_ids.append(task_id)
@@ -404,10 +474,18 @@ class TaskQueueRunner(BatchAgent):
             triage_comment += f"\nEstimated hours: {triage.estimated_hours}"
         await self._add_comment(task_id, triage_comment)
 
+        # Resolve repo URL for this task
+        repo_url = await self._resolve_repo_url(task)
+        if repo_url:
+            logger.info(f"Resolved repo for {task_id}: {repo_url}")
+
         # Dry run: log and reset
         if self.config.dry_run:
+            use_lw = self._should_use_lightweight(triage, repo_url)
+            executor = "lightweight" if use_lw else f"orchestrator ({repo_url})"
             logger.info(
-                f"[DRY RUN] {task_id}: {triage.verdict.value} (confidence={triage.confidence:.0%})"
+                f"[DRY RUN] {task_id}: {triage.verdict.value} "
+                f"(confidence={triage.confidence:.0%}, executor={executor})"
             )
             self.report.tasks_processed.append(
                 ProcessedTask(
@@ -416,7 +494,7 @@ class TaskQueueRunner(BatchAgent):
                     triage_verdict=triage.verdict,
                     confidence=triage.confidence,
                     outcome="skipped",
-                    notes=f"Dry run. {triage.reasoning}",
+                    notes=f"Dry run. Executor: {executor}. {triage.reasoning}",
                     estimated_hours=triage.estimated_hours,
                 )
             )
@@ -433,10 +511,10 @@ class TaskQueueRunner(BatchAgent):
         # Route by verdict
         match triage.verdict:
             case TriageVerdict.FULLY_EXECUTABLE:
-                if self._should_use_lightweight(triage):
+                if self._should_use_lightweight(triage, repo_url):
                     await self._execute_lightweight_task(task, triage)
                 else:
-                    await self._execute_task(task, triage)
+                    await self._execute_task(task, triage, repo_url=repo_url)
             case TriageVerdict.PRE_RESEARCH_ONLY:
                 await self._pre_research_task(task, triage)
             case TriageVerdict.NOT_ACTIONABLE:
@@ -444,7 +522,9 @@ class TaskQueueRunner(BatchAgent):
             case _:
                 logger.warning(f"Unexpected triage verdict: {triage.verdict}")
 
-    async def _execute_task(self, task: dict, triage: TriageResult) -> None:
+    async def _execute_task(
+        self, task: dict, triage: TriageResult, *, repo_url: str | None = None
+    ) -> None:
         """Execute a task via the orchestrator state machine."""
         task_id = task.get("id", "unknown")
         title = task.get("title", "Untitled")
@@ -465,7 +545,7 @@ class TaskQueueRunner(BatchAgent):
             )
             orch = Orchestrator(
                 config=orch_config,
-                git_repo_url=self.config.git_repo_url,
+                git_repo_url=repo_url,
             )
 
             # Add task and run
@@ -490,6 +570,8 @@ class TaskQueueRunner(BatchAgent):
 
                 # Comment with completion details
                 completion_comment = "Task completed via orchestrator."
+                if root_result.pr_url:
+                    completion_comment += f"\nPR: {root_result.pr_url}"
                 if root_result.branch_name:
                     completion_comment += f"\nBranch: `{root_result.branch_name}`"
                 if root_result.worker_output:
@@ -646,16 +728,16 @@ class TaskQueueRunner(BatchAgent):
             )
             self.context.failed_ids.append(task_id)
 
-    def _should_use_lightweight(self, triage: TriageResult) -> bool:
+    def _should_use_lightweight(self, triage: TriageResult, repo_url: str | None) -> bool:
         """Determine if a task should use the lightweight executor.
 
-        Returns True for non-code tasks, or code tasks without a configured repo.
+        Returns True for non-code tasks, or code tasks without a resolved repo.
         """
         action = triage.suggested_action_type
         if action != "code":
             return True
-        # Code task but no repo configured — can't use orchestrator
-        if not self.config.git_repo_url:
+        # Code task but no repo resolved — can't use orchestrator
+        if not repo_url:
             return True
         return False
 
@@ -738,6 +820,11 @@ class TaskQueueRunner(BatchAgent):
                     logger.warning(f"Failed to update task status: {e}")
 
                 fail_comment = f"Lightweight execution failed: {error_msg[:_ERROR_PREVIEW]}"
+                if action_type == "code":
+                    fail_comment += (
+                        "\n\nThis is a code task but no git repository was resolved. "
+                        "Set the task category to a known project or specify --repo."
+                    )
                 if result.output:
                     fail_comment += f"\n\nPartial output:\n{result.output[:_OUTPUT_PREVIEW]}"
                 await self._add_comment(task_id, fail_comment)

--- a/scripts/cleanup_workspaces.py
+++ b/scripts/cleanup_workspaces.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Garbage-collect stale Claude Code workspaces.
+
+Scans the workspaces directory, checks the age of each workspace (via
+``git log`` for the last commit time, falling back to directory mtime),
+and deletes any that exceed the configured max age.
+
+Usage:
+    uv run python scripts/cleanup_workspaces.py                # dry run by default
+    uv run python scripts/cleanup_workspaces.py --delete       # actually delete
+    uv run python scripts/cleanup_workspaces.py --max-age 5    # 5-day threshold
+    uv run python scripts/cleanup_workspaces.py --dir /tmp/ws  # custom directory
+
+Intended to be run via cron or systemd timer, e.g.:
+    0 3 * * * cd /home/user/build/agents && uv run python scripts/cleanup_workspaces.py --delete
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess  # nosec B404
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_WORKSPACES_DIR = Path.home() / ".claude_code_workspaces"
+DEFAULT_MAX_AGE_DAYS = 3
+
+
+def _last_commit_epoch(workspace: Path) -> float | None:
+    """Get epoch timestamp of the most recent git commit in a workspace."""
+    if not (workspace / ".git").exists():
+        return None
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            ["git", "log", "-1", "--format=%ct"],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return float(result.stdout.strip())
+    except (subprocess.TimeoutExpired, ValueError, OSError):
+        pass
+    return None
+
+
+def _workspace_age_epoch(workspace: Path) -> float:
+    """Best-effort timestamp of last meaningful activity in a workspace.
+
+    Uses the last git commit time if available, otherwise falls back to
+    the directory's mtime.
+    """
+    commit_time = _last_commit_epoch(workspace)
+    if commit_time is not None:
+        return commit_time
+    return workspace.stat().st_mtime
+
+
+def _format_age(seconds: float) -> str:
+    """Human-readable age string."""
+    days = seconds / 86400
+    if days >= 1:
+        return f"{days:.1f}d"
+    hours = seconds / 3600
+    return f"{hours:.1f}h"
+
+
+def cleanup_workspaces(
+    workspaces_dir: Path,
+    max_age_days: float,
+    delete: bool,
+    force: bool,
+) -> None:
+    """Scan and remove stale workspaces."""
+    if not workspaces_dir.is_dir():
+        print(f"Workspaces directory does not exist: {workspaces_dir}")
+        sys.exit(0)
+
+    now = time.time()
+    max_age_seconds = max_age_days * 86400
+
+    entries = sorted(workspaces_dir.iterdir())
+    workspaces = [e for e in entries if e.is_dir()]
+
+    if not workspaces:
+        print("No workspaces found.")
+        return
+
+    stale: list[tuple[Path, float]] = []
+    fresh: list[tuple[Path, float]] = []
+
+    for ws in workspaces:
+        age_epoch = _workspace_age_epoch(ws)
+        age_seconds = now - age_epoch
+        if age_seconds > max_age_seconds:
+            stale.append((ws, age_seconds))
+        else:
+            fresh.append((ws, age_seconds))
+
+    # Report
+    print(f"Workspaces directory: {workspaces_dir}")
+    print(f"Max age: {max_age_days} days")
+    print(f"Total: {len(workspaces)} | Stale: {len(stale)} | Fresh: {len(fresh)}")
+    print()
+
+    if not stale:
+        print("Nothing to clean up.")
+        return
+
+    for ws, age in stale:
+        action = "DELETE" if delete else "WOULD DELETE"
+        print(f"  [{action}] {ws.name}  (age: {_format_age(age)})")
+
+    print()
+
+    if not delete:
+        print("Dry run — pass --delete to actually remove these workspaces.")
+        return
+
+    deleted = 0
+    errors = 0
+    for ws, _age in stale:
+        # Safety check: skip workspaces with uncommitted changes unless forced
+        if not force and (ws / ".git").exists():
+            try:
+                result = subprocess.run(  # nosec B603 B607
+                    ["git", "status", "--porcelain"],
+                    cwd=ws,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    print(f"  SKIPPED {ws.name} (uncommitted changes, use --force)")
+                    continue
+            except (subprocess.TimeoutExpired, OSError):
+                pass
+
+        try:
+            shutil.rmtree(ws)
+            deleted += 1
+        except OSError as e:
+            print(f"  ERROR deleting {ws.name}: {e}")
+            errors += 1
+
+    print(f"Deleted {deleted} workspace(s).", end="")
+    if errors:
+        print(f" {errors} error(s).", end="")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Garbage-collect stale Claude Code workspaces.",
+    )
+    parser.add_argument(
+        "--dir",
+        type=Path,
+        default=DEFAULT_WORKSPACES_DIR,
+        help=f"Workspaces directory (default: {DEFAULT_WORKSPACES_DIR})",
+    )
+    parser.add_argument(
+        "--max-age",
+        type=float,
+        default=DEFAULT_MAX_AGE_DAYS,
+        help=f"Max age in days before a workspace is considered stale (default: {DEFAULT_MAX_AGE_DAYS})",
+    )
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Actually delete stale workspaces (default is dry run)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Delete even if workspace has uncommitted git changes",
+    )
+    args = parser.parse_args()
+
+    cleanup_workspaces(
+        workspaces_dir=args.dir,
+        max_age_days=args.max_age,
+        delete=args.delete,
+        force=args.force,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `PUBLISH` phase to orchestrator state machine between REVIEW and COMPLETE — pushes branch and creates a GitHub PR via `run_claude_code`
- PR body includes task ID and clickable TaskManager link (when `TASKMANAGER_URL` env var is set)
- Add workspace garbage collection script (`scripts/cleanup_workspaces.py`) — dry-run by default, deletes workspaces not updated in 3+ days
- Add repo map routing for task queue runner (category -> git repo URL lookup via `repo_map.json`)

## Changes

**Orchestrator pipeline** (`agents/orchestrator/`):
- `models.py`: `Phase.PUBLISH` enum value, `Task.pr_url` field
- `workers.py`: `push_and_create_pr()` + `_extract_pr_url()` helper
- `state_machine.py`: `_publish_task()` method wired between review and finalize (best-effort, non-fatal on failure)

**Task queue runner** (`agents/task_queue/runner.py`):
- Surface `pr_url` in completion comments

**New script** (`scripts/cleanup_workspaces.py`):
- Scans `~/.claude_code_workspaces/`, checks age via `git log` (fallback: dir mtime), deletes stale ones
- Supports `--delete`, `--max-age`, `--force`, `--dir` flags

## Test plan

- [x] Run a code task with category set — verify PUBLISH phase in logs, branch pushed, PR created on GitHub
- [x] Check PR has correct title, targets base branch (main), and includes task ID
- [x] If push fails (e.g. no remote), task should still complete without error
- [x] Run `uv run python scripts/cleanup_workspaces.py` — verify dry run lists stale workspaces
- [x] Run with `--delete` — verify stale workspaces are removed, fresh ones preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)