### PR TITLE
Skip task decomposition for small tasks

### DIFF
--- a/agents/orchestrator/models.py
+++ b/agents/orchestrator/models.py
@@ -212,6 +212,9 @@ class Task:
     pr_url: str | None = None
     error: str | None = None
 
+    # Estimation
+    estimated_hours: float | None = None
+
     # Metadata
     created_at: datetime = field(default_factory=_utcnow)
     started_at: datetime | None = None
@@ -236,7 +239,8 @@ class Task:
 class OrchestratorConfig:
     """Configuration for the orchestrator."""
 
-    # Recursion and task limits
+    # Decomposition
+    decompose_threshold_hours: float = 4.0  # Skip decomposition for tasks estimated ≤ this
     max_subtask_depth: int = 3
     max_subtasks_per_task: int = 6
     max_remediation_tasks: int = 3

--- a/agents/orchestrator/state_machine.py
+++ b/agents/orchestrator/state_machine.py
@@ -300,6 +300,7 @@ class Orchestrator:
         - They're already subtasks at max depth
         - They're already decomposed (have subtask_ids)
         - Their description is very short (likely already atomic)
+        - Their estimated hours are at or below the threshold (small enough to do in one shot)
         """
         if task.depth >= self.config.max_subtask_depth:
             return False
@@ -307,6 +308,16 @@ class Orchestrator:
             return False
         # Short descriptions suggest atomic tasks
         if len(task.description) < 100:
+            return False
+        # Small tasks don't need decomposition
+        if (
+            task.estimated_hours is not None
+            and task.estimated_hours <= self.config.decompose_threshold_hours
+        ):
+            logger.info(
+                f"Skipping decomposition for {task.id}: "
+                f"estimated {task.estimated_hours}h <= {self.config.decompose_threshold_hours}h threshold"
+            )
             return False
         return True
 

--- a/agents/task_queue/prompts.py
+++ b/agents/task_queue/prompts.py
@@ -23,7 +23,7 @@ Respond with a JSON object (no markdown fences):
   "verdict": "fully_executable" | "pre_research_only" | "not_actionable",
   "confidence": 0.0-1.0,
   "reasoning": "Brief explanation of classification",
-  "estimated_hours": null or float,
+  "estimated_hours": float (REQUIRED - always estimate how many hours this would take a developer, e.g. 0.5, 1.0, 4.0),
   "suggested_action_type": "research" | "code" | "email" | "document" | "review" | "data_entry" | "other" | null,
   "suggested_autonomy_tier": 1-4 or null,
   "suggested_dependencies": [],

--- a/agents/task_queue/runner.py
+++ b/agents/task_queue/runner.py
@@ -558,7 +558,8 @@ class TaskQueueRunner(BatchAgent):
                     accumulated_context=accumulated_context,
                     model=self.config.triage_model,
                 )
-                print(f"  {task_id}: {triage.verdict.value} ({triage.confidence:.0%})")
+                hours_str = f", ~{triage.estimated_hours:.1f}h" if triage.estimated_hours else ""
+                print(f"  {task_id}: {triage.verdict.value} ({triage.confidence:.0%}{hours_str})")
                 return (task, triage, "")
             except Exception as e:
                 logger.error(f"Triage failed for {task_id}: {e}")
@@ -570,6 +571,21 @@ class TaskQueueRunner(BatchAgent):
         self, task: dict, task_id: str, title: str, triage: TriageResult
     ) -> None:
         """Route a pre-triaged task to the appropriate executor."""
+        # Reconcile estimated_hours: prefer existing task value, write back triage estimate if missing
+        task_estimate = task.get("estimated_hours")
+        if task_estimate is not None:
+            triage.estimated_hours = float(task_estimate)
+            logger.info(f"Using existing estimated_hours={task_estimate} for {task_id}")
+        elif triage.estimated_hours is not None:
+            try:
+                await self.call_tool(
+                    "update_task",
+                    {"task_id": task_id, "estimated_hours": triage.estimated_hours},
+                )
+                logger.info(f"Wrote triage estimate ({triage.estimated_hours}h) to {task_id}")
+            except Exception as e:
+                logger.warning(f"Failed to write estimated_hours for {task_id}: {e}")
+
         # Classify in TaskManager if unclassified
         if not task.get("action_type") and triage.suggested_action_type:
             try:
@@ -677,8 +693,18 @@ class TaskQueueRunner(BatchAgent):
             orch.add_task(orch_task)
             results = await orch.run(max_tasks=10)
 
-            # Always sync subtasks to TaskManager (even if execution failed)
-            await self._sync_subtasks_to_taskmanager(task_id, orch, orch_task)
+            # Sync subtasks to TaskManager only if at least one subtask succeeded
+            subtasks = orch.get_subtasks(orch_task.id)
+            any_subtask_succeeded = any(
+                st.status.value in ("completed", "in_progress", "in_review", "awaiting_human")
+                for st in subtasks
+            )
+            if any_subtask_succeeded:
+                await self._sync_subtasks_to_taskmanager(task_id, orch, orch_task)
+            elif subtasks:
+                logger.info(
+                    f"Skipping subtask sync for {task_id}: all {len(subtasks)} subtasks failed"
+                )
 
             # Determine outcome
             if not results:
@@ -1176,6 +1202,7 @@ class TaskQueueRunner(BatchAgent):
             tags=mcp_task.get("tags", []),
             category=mcp_task.get("category", ""),
             external_id=mcp_task.get("id"),
+            estimated_hours=triage.estimated_hours,
         )
 
     async def _send_batch_notification(self) -> None:


### PR DESCRIPTION
## Summary
- Use triage's `estimated_hours` (or the task's existing value from TaskManager) to skip decomposition for tasks ≤ 4 hours
- Triage prompt now always returns an hour estimate instead of allowing null
- Write triage estimates back to TaskManager so they persist across runs
- Don't sync subtasks to TaskManager when all orchestrator workers failed

## Details
The orchestrator was decomposing every task with a description over 100 chars into subtasks, even straightforward changes like "add an enum field." Now the decomposition decision is based on estimated hours:
- Tasks ≤ 4h execute directly in a single worker session
- Tasks > 4h decompose into subtasks as before
- If the task already has `estimated_hours` set in TaskManager, that value is used (no re-estimation)
- If not, triage's estimate is written back to the task for future runs

## Test plan
- [x] All 336 tests pass
- [x] Verified triage now always returns `estimated_hours`
- [x] Verified `_should_decompose` returns False for tasks ≤ 4h, True for > 4h
- [x] Verified estimate write-back persists to TaskManager
- [x] Verified second run reads existing estimate instead of re-estimating
- [x] Verified failed subtasks are not synced to TaskManager

🤖 Generated with [Claude Code](https://claude.com/claude-code)