### PR TITLE
Add live demo script for security features

### DIFF
--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -44,10 +44,10 @@ uv run python scripts/demo_live.py memory
 - Agent name validation blocks path traversal (`../`), null bytes, and non-alphanumeric characters.
 
 **Key code:**
-- Auto-injection: `agent.py` line ~645-651
-- Namespace validation: `tools/memory.py` lines 47-82
-- File isolation: `storage/memory_store.py` line 103
-- DB isolation: `storage/database_memory_store.py` — `WHERE agent_name = $1` on every query
+- Auto-injection: `Agent._call_mcp_tool_with_reconnect()` in `core/agent.py`
+- Namespace validation: `validate_agent_name()` in `tools/memory.py`
+- File isolation: `MemoryStore.__init__()` in `storage/memory_store.py`
+- DB isolation: `DatabaseMemoryStore` — `WHERE agent_name = $1` on every query
 
 ---
 
@@ -86,10 +86,10 @@ uv run python scripts/demo_live.py ssrf
 - Permission intersection means a low-privilege caller can never escalate by delegating to a high-privilege agent.
 
 **Key code:**
-- SSRF validator: `security/ssrf.py`
-- Permission check: `agent.py` lines 578-603
-- Tool permission map: `permissions/tool_permissions.py`
-- ExecutionContext delegation: `permissions/context.py` lines 108-165
+- SSRF validator: `SSRFValidator` in `security/ssrf.py`
+- Permission check: `Agent._check_tool_permissions()` in `core/agent.py`
+- Tool permission map: `TOOL_PERMISSIONS` in `permissions/tool_permissions.py`
+- ExecutionContext delegation: `ExecutionContext.delegate_to()` in `permissions/context.py`
 
 ---
 
@@ -118,7 +118,7 @@ uv run python scripts/demo_live.py trimming
 - **Belt and suspenders:** Structured metadata is preferred, but pattern matching is a fallback for messages that describe security events (e.g., "your request was flagged by our security system").
 
 **Key code:**
-- Tagging at enforcement: `agent.py` lines ~1140 (permission) and ~1175 (SSRF)
-- Classification: `security/context_trimming.py` — `classify_message()`
-- 8-phase trim algorithm: `security/context_trimming.py` — `trim_with_security_awareness()`
-- Redacted summary builder: `security/context_trimming.py` — `_build_security_summary()`
+- Tagging at enforcement: `SECURITY_EVENT_KEY` tagging in `Agent._call_mcp_tool_with_reconnect()`
+- Classification: `classify_message()` in `security/context_trimming.py`
+- 8-phase trim algorithm: `trim_with_security_awareness()` in `security/context_trimming.py`
+- Redacted summary builder: `_build_security_summary()` in `security/context_trimming.py`

--- a/scripts/demo_live.py
+++ b/scripts/demo_live.py
@@ -35,7 +35,7 @@ from agent_framework.security.context_trimming import (  # noqa: E402
     trim_with_security_awareness,
 )
 from agent_framework.security.ssrf import SSRFValidator  # noqa: E402
-from agent_framework.tools.memory import save_memory, search_memories  # noqa: E402
+from agent_framework.tools.memory import delete_memory, save_memory, search_memories  # noqa: E402
 
 # ── Formatting helpers ───────────────────────────────────────────────────────
 
@@ -86,61 +86,61 @@ async def demo_memory_namespace() -> None:
     agent_a = "DemoAgent-Alpha"
     agent_b = "DemoAgent-Beta"
 
-    # ── Save memories under each namespace ──────────────────────────────────
-    section("Saving memories into two namespaces")
+    try:
+        # ── Save memories under each namespace ──────────────────────────────
+        section("Saving memories into two namespaces")
 
-    await save_memory(
-        key="demo-project-status",
-        value="Alpha team: launching rocket to Mars next quarter",
-        category="project",
-        importance=8,
-        agent_name=agent_a,
-    )
-    ok(f'{agent_a} saved: "launching rocket to Mars next quarter"')
+        await save_memory(
+            key="demo-project-status",
+            value="Alpha team: launching rocket to Mars next quarter",
+            category="project",
+            importance=8,
+            agent_name=agent_a,
+        )
+        ok(f'{agent_a} saved: "launching rocket to Mars next quarter"')
 
-    await save_memory(
-        key="demo-project-status",
-        value="Beta team: building underwater data center in the Pacific",
-        category="project",
-        importance=8,
-        agent_name=agent_b,
-    )
-    ok(f'{agent_b} saved: "building underwater data center in the Pacific"')
+        await save_memory(
+            key="demo-project-status",
+            value="Beta team: building underwater data center in the Pacific",
+            category="project",
+            importance=8,
+            agent_name=agent_b,
+        )
+        ok(f'{agent_b} saved: "building underwater data center in the Pacific"')
 
-    # ── Search with the same query from each namespace ──────────────────────
-    section('Searching both namespaces for "project"')
+        # ── Search with the same query from each namespace ──────────────────
+        section('Searching both namespaces for "project"')
 
-    result_a = await search_memories(query="project", agent_name=agent_a)
-    result_b = await search_memories(query="project", agent_name=agent_b)
+        result_a = await search_memories(query="project", agent_name=agent_a)
+        result_b = await search_memories(query="project", agent_name=agent_b)
 
-    memories_a = result_a.get("memories", [])
-    memories_b = result_b.get("memories", [])
+        memories_a = result_a.get("memories", [])
+        memories_b = result_b.get("memories", [])
 
-    info(f"{agent_a} sees {len(memories_a)} result(s):")
-    for m in memories_a:
-        print(f"    {CYAN}{m['key']}{RESET}: {m['value']}")
+        info(f"{agent_a} sees {len(memories_a)} result(s):")
+        for m in memories_a:
+            print(f"    {CYAN}{m['key']}{RESET}: {m['value']}")
 
-    info(f"{agent_b} sees {len(memories_b)} result(s):")
-    for m in memories_b:
-        print(f"    {CYAN}{m['key']}{RESET}: {m['value']}")
+        info(f"{agent_b} sees {len(memories_b)} result(s):")
+        for m in memories_b:
+            print(f"    {CYAN}{m['key']}{RESET}: {m['value']}")
 
-    # ── Cross-namespace check ───────────────────────────────────────────────
-    section("Cross-namespace verification")
+        # ── Cross-namespace check ───────────────────────────────────────────
+        section("Cross-namespace verification")
 
-    # Search Agent A's namespace for Agent B's content
-    cross = await search_memories(query="underwater", agent_name=agent_a)
-    cross_results = cross.get("memories", [])
-    if not cross_results:
-        ok(f'{agent_a} searching "underwater" → 0 results (isolation works)')
-    else:
-        blocked(f"{agent_a} found {len(cross_results)} result(s) — isolation broken!")
+        # Search Agent A's namespace for Agent B's content
+        cross = await search_memories(query="underwater", agent_name=agent_a)
+        cross_results = cross.get("memories", [])
+        if not cross_results:
+            ok(f'{agent_a} searching "underwater" → 0 results (isolation works)')
+        else:
+            blocked(f"{agent_a} found {len(cross_results)} result(s) — isolation broken!")
 
-    # ── Cleanup ─────────────────────────────────────────────────────────────
-    from agent_framework.tools.memory import delete_memory
-
-    await delete_memory(key="demo-project-status", agent_name=agent_a)
-    await delete_memory(key="demo-project-status", agent_name=agent_b)
-    info("Cleaned up demo memories")
+    finally:
+        # ── Cleanup (runs even on error/Ctrl-C) ────────────────────────────
+        await delete_memory(key="demo-project-status", agent_name=agent_a)
+        await delete_memory(key="demo-project-status", agent_name=agent_b)
+        info("Cleaned up demo memories")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -245,7 +245,7 @@ async def demo_ssrf_permissions() -> None:
 async def demo_security_trimming() -> None:
     banner(3, "Security Events Survive Trimming", "Long conversation, pinned events persist")
 
-    # Build a synthetic conversation with 30 messages (mix of normal + security)
+    # Build a synthetic conversation with 44 messages (mix of normal + security)
     messages: list[dict] = []
 
     # Normal conversation padding (turns 1-10)


### PR DESCRIPTION
## Summary
- Adds `scripts/demo_live.py` — a single runnable demo covering memory namespace isolation, SSRF + permission denial, and security events surviving context trimming
- Adds `docs/DEMO_SCRIPT.md` — presenter's guide with exact commands, talking points, and key code references
- No new dependencies or API keys required; exercises existing framework code directly

## Test plan
- [x] `uv run python scripts/demo_live.py` runs all 3 steps successfully
- [x] `uv run python scripts/demo_live.py memory` / `ssrf` / `trimming` work individually
- [x] Pre-commit hooks pass (ruff, pyright, pytest, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)