### PR TITLE
Fix PR Shepherd SSH URLs and explicit worker model

### DIFF
--- a/agents/pr_shepherd/main.py
+++ b/agents/pr_shepherd/main.py
@@ -169,7 +169,7 @@ class PRShepherd:
             logger.error(f"Invalid workspace name: {workspace_name!r}")
             return
 
-        git_url = f"https://github.com/{pr.repo}.git"
+        git_url = f"git@github.com:{pr.repo}.git"
 
         ws_result = await create_claude_code_workspace(
             folder_name=workspace_name,
@@ -192,10 +192,6 @@ class PRShepherd:
                 / workspace_name
             )
             logger.warning(f"workspace_path not in result, reconstructed: {workspace_path}")
-
-        # Configure gh as credential helper so push works with HTTPS clones
-        if not await github_ops.configure_git_credentials(workspace_path):
-            logger.warning(f"Could not configure git credentials for {workspace_path}")
 
         # Checkout the PR branch
         try:

--- a/packages/agent-framework/agent_framework/tools/claude_code.py
+++ b/packages/agent-framework/agent_framework/tools/claude_code.py
@@ -268,9 +268,9 @@ async def run_claude_code(
             str(max_turns),
         ]
 
-        # Add model if not default
-        if model.lower() != "sonnet":
-            claude_cmd.extend(["--model", model_map[model.lower()]])
+        # Always pass --model explicitly to avoid inheriting the user's
+        # default (which may differ from the intended worker model).
+        claude_cmd.extend(["--model", model_map[model.lower()]])
 
         logger.info(f"Running Claude Code in {workspace_path} with command: {command[:100]}...")
 


### PR DESCRIPTION
## Summary
- **PR Shepherd SSH URL**: Changed `https://github.com/{repo}.git` to `git@github.com:{repo}.git` in `agents/pr_shepherd/main.py` — same fix applied to the orchestrator in #119, but PR Shepherd was missed
- **Explicit --model flag**: `run_claude_code()` now always passes `--model` to the `claude` CLI instead of omitting it when set to "sonnet" — previously workers silently inherited the user's configured default model (e.g. Opus 4.6)
- Removed the now-unnecessary HTTPS credential helper setup since SSH uses key-based auth

## Test plan
- [x] Ran PR Shepherd against `brooksmcmillin/taskmanager` — successfully fixed CI failures on PRs #234 and #235, all checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)